### PR TITLE
Fix panic during printing error request message

### DIFF
--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -218,7 +218,17 @@ type APIErrorDetail struct {
 }
 
 func (e *APIErrorDetail) Error() string {
-	return fmt.Sprintf("%s: %s", *e.Type, *e.Description)
+	msg := ""
+
+	if e.Type != nil {
+		msg = *e.Type + ": "
+	}
+
+	if e.Description != nil {
+		msg += *e.Description
+	}
+
+	return msg
 }
 
 // Bool is a helper function that returns a pointer to the bool value b.


### PR DESCRIPTION
Error messages received from the API panic during printing with the `fmt`. This happens when some of the fields are missing due to dereferencing a nil pointer. As an example:

```
POST https://xxxxx.zendesk.com/api/v2/tickets.json: 422 RecordInvalid: Record validation errors: map[base:[%!v(PANIC=runtime error: invalid memory address or nil pointer dereference)]]
```
