### PR TITLE
Allow creation of a ticket with a new requester in one call

### DIFF
--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -23,6 +23,7 @@ type Ticket struct {
 	Status          *string        `json:"status,omitempty"`
 	Recipient       *string        `json:"recipient,omitempty"`
 	RequesterID     *int64         `json:"requester_id,omitempty"`
+	Requester       *User          `json:"requester,omitempty"`
 	SubmitterID     *int64         `json:"submitter_id,omitempty"`
 	AssigneeID      *int64         `json:"assignee_id,omitempty"`
 	OrganizationID  *int64         `json:"organization_id,omitempty"`


### PR DESCRIPTION
According to Zendesk API documentation is possible to create a new requester also in ticket creation

https://developer.zendesk.com/rest_api/docs/core/tickets#creating-a-ticket-with-a-new-requester

So I added Requester as pointer to User in Ticket struct and it works.
