### PR TITLE
Search Zendesk organizations using company name

### DIFF
--- a/zendesk/org.go
+++ b/zendesk/org.go
@@ -2,6 +2,7 @@ package zendesk
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -74,4 +75,14 @@ func (c *client) ListOrganizations(opts *ListOptions) ([]Organization, error) {
 // Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/organizations#delete-organization
 func (c *client) DeleteOrganization(id int64) error {
 	return c.delete(fmt.Sprintf("/api/v2/organizations/%d.json", id), nil)
+}
+
+// AutocompleteOrganizations returns an array of organizations whose name starts with the value specified in the name parameter.
+// Note: name is case-insensitive
+// Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/organizations#autocomplete-organizations
+func (c *client) AutocompleteOrganizations(name string) ([]Organization, error) {
+	out := new(APIPayload)
+	name = url.QueryEscape(name)
+	err := c.get("/api/v2/organizations/autocomplete.json?name="+name, out)
+	return out.Organizations, err
 }

--- a/zendesk/org_test.go
+++ b/zendesk/org_test.go
@@ -65,3 +65,30 @@ func TestOrganizationList(t *testing.T) {
 
 	require.NotEqual(t, *first[0].ID, *second[0].ID)
 }
+
+func TestAutocompleteOrganizations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode.")
+	}
+
+	client, err := NewEnvClient()
+	require.NoError(t, err)
+
+	organizations, err := client.AutocompleteOrganizations("very fake clinic")
+	require.NoError(t, err)
+	require.Len(t, organizations, 0)
+
+	org1 := randOrg(t, client)
+	defer client.DeleteOrganization(*org1.ID)
+
+	organizations, err = client.AutocompleteOrganizations("very fake clinic")
+	require.NoError(t, err)
+	require.Len(t, organizations, 1)
+
+	org2 := randOrg(t, client)
+	defer client.DeleteOrganization(*org2.ID)
+
+	organizations, err = client.AutocompleteOrganizations("very fake clinic")
+	require.NoError(t, err)
+	require.Len(t, organizations, 2)
+}

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -20,6 +20,7 @@ type Client interface {
 	WithHeader(name, value string) Client
 
 	AddUserTags(int64, []string) ([]string, error)
+	AutocompleteOrganizations(string) ([]Organization, error)
 	BatchUpdateManyTickets([]Ticket) error
 	BulkUpdateManyTickets([]int64, *Ticket) error
 	CreateIdentity(int64, *UserIdentity) (*UserIdentity, error)


### PR DESCRIPTION
We want the ability to search Zendesk Organizations by organization name. There are multiple ways to do this, but the easiest is via the [Autocomplete Organizations API](https://developer.zendesk.com/rest_api/docs/core/organizations#autocomplete-organizations).

### Added
- a new method called `AutocompleteOrganizations` for searching Zendesk organizations using a company name

### Updated
- `Client` interface to include the new `AutocompleteOrganizations` method