### PR TITLE
Add support to search user by external_id

### DIFF
--- a/zendesk/user.go
+++ b/zendesk/user.go
@@ -171,6 +171,18 @@ func (c *client) SearchUsers(query string) ([]User, error) {
 	return out.Users, err
 }
 
+// SearchUsersByExternalID searches users by external_id.
+//
+// Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/users#search-users
+func (c *client) SearchUserByExternalID(externalID string) (*User, error) {
+	out := new(APIPayload)
+	err := c.get("/api/v2/users/search.json?external_id="+externalID, out)
+	if len(out.Users) != 1 {
+		return nil, err
+	}
+	return &out.Users[0], err
+}
+
 // AddUserTags adds a tag to a user
 //
 // Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/tags#add-tags

--- a/zendesk/user_test.go
+++ b/zendesk/user_test.go
@@ -15,8 +15,9 @@ func TestUserCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	input := User{
-		Name:  String(randString(16)),
-		Email: String(randString(16) + "@example.com"),
+		Name:       String(randString(16)),
+		Email:      String(randString(16) + "@example.com"),
+		ExternalID: String(randString(16)),
 	}
 
 	created, err := client.CreateUser(&input)
@@ -24,6 +25,7 @@ func TestUserCRUD(t *testing.T) {
 	require.NotNil(t, created.ID)
 	require.Equal(t, *input.Name, *created.Name)
 	require.Equal(t, *input.Email, *created.Email)
+	require.Equal(t, *input.ExternalID, *created.ExternalID)
 	require.True(t, *created.Active)
 
 	found, err := client.ShowUser(*created.ID)
@@ -31,6 +33,7 @@ func TestUserCRUD(t *testing.T) {
 	require.Equal(t, *created.ID, *found.ID)
 	require.Equal(t, *input.Name, *found.Name)
 	require.Equal(t, *input.Email, *found.Email)
+	require.Equal(t, *input.ExternalID, *found.ExternalID)
 
 	input = User{
 		Name: String("Testy Testacular"),
@@ -44,6 +47,15 @@ func TestUserCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, searched, 1)
 	require.Equal(t, updated, &searched[0])
+
+	found, err = client.SearchUserByExternalID(*updated.ExternalID)
+	require.NoError(t, err)
+	require.Equal(t, updated, found)
+
+	var nilUser *User
+	found, err = client.SearchUserByExternalID("non-existent")
+	require.NoError(t, err)
+	require.Equal(t, nilUser, found)
 
 	other, err := client.CreateUser(&User{
 		Name:  String(randString(16)),

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -48,6 +48,7 @@ type Client interface {
 	PermanentlyDeleteUser(int64) (*User, error)
 	RedactCommentString(int64, int64, string) (*TicketComment, error)
 	SearchUsers(string) ([]User, error)
+	SearchUserByExternalID(string) (*User, error)
 	ShowComplianceDeletionStatuses(int64) ([]ComplianceDeletionStatus, error)
 	ShowIdentity(int64, int64) (*UserIdentity, error)
 	ShowJobStatus(string) (*JobStatus, error)


### PR DESCRIPTION
In my project's company, we use Zendesk SSO and the user external_id is our main way to find a specific user.