### PR TITLE
Support untyped (Additional) Collaborators & Requesters

### DIFF
--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -25,6 +25,7 @@ type Ticket struct {
 	Status                  *string        `json:"status,omitempty"`
 	Recipient               *string        `json:"recipient,omitempty"`
 	RequesterID             *int64         `json:"requester_id,omitempty"`
+	Requester               *Requester     `json:"requester,omitempty"`
 	SubmitterID             *int64         `json:"submitter_id,omitempty"`
 	AssigneeID              *int64         `json:"assignee_id,omitempty"`
 	AssigneeEmail           *string        `json:"assignee_email,omitempty"`
@@ -58,6 +59,12 @@ type CustomField struct {
 type Collaborator struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`
+}
+
+type Requester struct {
+	LocaleID *int   `json:"locale_id"`
+	Name     string `json:"name"`
+	Email    string `json:"email"`
 }
 
 func (c *client) ShowTicket(id int64) (*Ticket, error) {

--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -12,37 +12,39 @@ import (
 //
 // Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/tickets
 type Ticket struct {
-	ID               *int64         `json:"id,omitempty"`
-	URL              *string        `json:"url,omitempty"`
-	ExternalID       *string        `json:"external_id,omitempty"`
-	Type             *string        `json:"type,omitempty"`
-	Subject          *string        `json:"subject,omitempty"`
-	RawSubject       *string        `json:"raw_subject,omitempty"`
-	Description      *string        `json:"description,omitempty"`
-	Comment          *TicketComment `json:"comment,omitempty"`
-	CommentCount     *int64         `json:"comment_count,omitempty"`
-	Priority         *string        `json:"priority,omitempty"`
-	Status           *string        `json:"status,omitempty"`
-	Recipient        *string        `json:"recipient,omitempty"`
-	RequesterID      *int64         `json:"requester_id,omitempty"`
-	SubmitterID      *int64         `json:"submitter_id,omitempty"`
-	AssigneeID       *int64         `json:"assignee_id,omitempty"`
-	AssigneeEmail    *string        `json:"assignee_email,omitempty"`
-	OrganizationID   *int64         `json:"organization_id,omitempty"`
-	GroupID          *int64         `json:"group_id,omitempty"`
-	CollaboratorIDs  []int64        `json:"collaborator_ids,omitempty"`
-	ForumTopicID     *int64         `json:"forum_topic_id,omitempty"`
-	ProblemID        *int64         `json:"problem_id,omitempty"`
-	HasIncidents     *bool          `json:"has_incidents,omitempty"`
-	DueAt            *time.Time     `json:"due_at,omitempty"`
-	Tags             []string       `json:"tags,omitempty"`
-	Via              *Via           `json:"via,omitempty"`
-	CreatedAt        *time.Time     `json:"created_at,omitempty"`
-	UpdatedAt        *time.Time     `json:"updated_at,omitempty"`
-	CustomFields     []CustomField  `json:"custom_fields,omitempty"`
-	BrandID          *int64         `json:"brand_id,omitempty"`
-	TicketFormID     *int64         `json:"ticket_form_id,omitempty"`
-	FollowupSourceID *int64         `json:"via_followup_source_id,omitempty"`
+	ID                      *int64         `json:"id,omitempty"`
+	URL                     *string        `json:"url,omitempty"`
+	ExternalID              *string        `json:"external_id,omitempty"`
+	Type                    *string        `json:"type,omitempty"`
+	Subject                 *string        `json:"subject,omitempty"`
+	RawSubject              *string        `json:"raw_subject,omitempty"`
+	Description             *string        `json:"description,omitempty"`
+	Comment                 *TicketComment `json:"comment,omitempty"`
+	CommentCount            *int64         `json:"comment_count,omitempty"`
+	Priority                *string        `json:"priority,omitempty"`
+	Status                  *string        `json:"status,omitempty"`
+	Recipient               *string        `json:"recipient,omitempty"`
+	RequesterID             *int64         `json:"requester_id,omitempty"`
+	SubmitterID             *int64         `json:"submitter_id,omitempty"`
+	AssigneeID              *int64         `json:"assignee_id,omitempty"`
+	AssigneeEmail           *string        `json:"assignee_email,omitempty"`
+	OrganizationID          *int64         `json:"organization_id,omitempty"`
+	GroupID                 *int64         `json:"group_id,omitempty"`
+	CollaboratorIDs         []int64        `json:"collaborator_ids,omitempty"`
+	Collaborators           []interface{}  `json:"collaborators,omitempty"`
+	AdditionalCollaborators []interface{}  `json:"additional_collaborators,omitempty"`
+	ForumTopicID            *int64         `json:"forum_topic_id,omitempty"`
+	ProblemID               *int64         `json:"problem_id,omitempty"`
+	HasIncidents            *bool          `json:"has_incidents,omitempty"`
+	DueAt                   *time.Time     `json:"due_at,omitempty"`
+	Tags                    []string       `json:"tags,omitempty"`
+	Via                     *Via           `json:"via,omitempty"`
+	CreatedAt               *time.Time     `json:"created_at,omitempty"`
+	UpdatedAt               *time.Time     `json:"updated_at,omitempty"`
+	CustomFields            []CustomField  `json:"custom_fields,omitempty"`
+	BrandID                 *int64         `json:"brand_id,omitempty"`
+	TicketFormID            *int64         `json:"ticket_form_id,omitempty"`
+	FollowupSourceID        *int64         `json:"via_followup_source_id,omitempty"`
 
 	AdditionalTags []string `json:"additional_tags,omitempty"`
 	RemoveTags     []string `json:"remove_tags,omitempty"`
@@ -51,6 +53,11 @@ type Ticket struct {
 type CustomField struct {
 	ID    *int64      `json:"id"`
 	Value interface{} `json:"value"`
+}
+
+type Collaborator struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 func (c *client) ShowTicket(id int64) (*Ticket, error) {

--- a/zendesk/ticket.go
+++ b/zendesk/ticket.go
@@ -57,14 +57,14 @@ type CustomField struct {
 }
 
 type Collaborator struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	Name  *string `json:"name,omitempty"`
+	Email *string `json:"email,omitempty"`
 }
 
 type Requester struct {
-	LocaleID *int   `json:"locale_id"`
-	Name     string `json:"name"`
-	Email    string `json:"email"`
+	LocaleID *int    `json:"locale_id"`
+	Name     *string `json:"name,omitempty"`
+	Email    *string `json:"email,omitempty"`
 }
 
 func (c *client) ShowTicket(id int64) (*Ticket, error) {

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -18,16 +18,18 @@ func TestTicketCRUD(t *testing.T) {
 	defer client.DeleteUser(*user.ID)
 
 	ticket := &Ticket{
-		Subject:     String("My printer is on fire!"),
-		Description: String("The smoke is very colorful."),
-		RequesterID: user.ID,
-		Tags:        []string{"test"},
+		Subject:       String("My printer is on fire!"),
+		Description:   String("The smoke is very colorful."),
+		RequesterID:   user.ID,
+		Tags:          []string{"test"},
+		Collaborators: []interface{}{"email@example.com", &Collaborator{Name: "NAME", Email: "email2@example.com"}},
 	}
 
 	created, err := client.CreateTicket(ticket)
 	require.NoError(t, err)
 	require.NotNil(t, created.ID)
-	require.Len(t, ticket.Tags, 1)
+	require.Len(t, created.Tags, 1)
+	require.Len(t, created.CollaboratorIDs, 2)
 
 	found, err := client.ShowTicket(*created.ID)
 	require.NoError(t, err)
@@ -37,11 +39,13 @@ func TestTicketCRUD(t *testing.T) {
 
 	input := Ticket{
 		Status: String("solved"),
+		AdditionalCollaborators: []interface{}{"email3@example.com"},
 	}
 
 	updated, err := client.UpdateTicket(*created.ID, &input)
 	require.NoError(t, err)
 	require.Equal(t, input.Status, updated.Status)
+	require.Len(t, updated.CollaboratorIDs, 3)
 
 	requested, err := client.ListRequestedTickets(*user.ID)
 	require.NoError(t, err)

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -22,7 +22,7 @@ func TestTicketCRUD(t *testing.T) {
 		Description:   String("The smoke is very colorful."),
 		RequesterID:   user.ID,
 		Tags:          []string{"test"},
-		Collaborators: []interface{}{"email@example.com", &Collaborator{Name: "NAME", Email: "email2@example.com"}},
+		Collaborators: []interface{}{"email@example.com", &Collaborator{Name: String("NAME"), Email: String("email2@example.com")}},
 	}
 
 	created, err := client.CreateTicket(ticket)
@@ -67,8 +67,8 @@ func TestTicketCRUD(t *testing.T) {
 		Subject:       String("My printer is on fire!"),
 		Description:   String("The smoke is very colorful."),
 		Tags:          []string{"test"},
-		Collaborators: []interface{}{"email@example.com", &Collaborator{Name: "NAME", Email: "email2@example.com"}},
-		Requester:     &Requester{Email: "email5@example.com", Name: "NAME2"},
+		Collaborators: []interface{}{"email@example.com", &Collaborator{Name: String("NAME"), Email: String("email2@example.com")}},
+		Requester:     &Requester{Email: String("email5@example.com"), Name: String("NAME2")},
 	}
 
 	createdReq, err := client.CreateTicket(ticketReq)

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -38,7 +38,7 @@ func TestTicketCRUD(t *testing.T) {
 	require.Equal(t, created.Tags, found.Tags)
 
 	input := Ticket{
-		Status: String("solved"),
+		Status:                  String("solved"),
 		AdditionalCollaborators: []interface{}{"email3@example.com"},
 	}
 
@@ -62,6 +62,26 @@ func TestTicketCRUD(t *testing.T) {
 	status, err := client.ShowJobStatus(*job.ID)
 	require.NoError(t, err)
 	require.NotNil(t, status.Status)
+
+	ticketReq := &Ticket{
+		Subject:       String("My printer is on fire!"),
+		Description:   String("The smoke is very colorful."),
+		Tags:          []string{"test"},
+		Collaborators: []interface{}{"email@example.com", &Collaborator{Name: "NAME", Email: "email2@example.com"}},
+		Requester:     &Requester{Email: "email5@example.com", Name: "NAME2"},
+	}
+
+	createdReq, err := client.CreateTicket(ticketReq)
+	require.NoError(t, err)
+	require.NotNil(t, createdReq.ID)
+
+	err = client.DeleteTicket(*createdReq.ID)
+	require.NoError(t, err)
+
+	jobReq, err := client.PermanentlyDeleteTicket(*createdReq.ID)
+	require.NoError(t, err)
+	require.NotNil(t, jobReq.ID)
+
 }
 
 func TestBatchUpdateManyTickets(t *testing.T) {


### PR DESCRIPTION
Add support for `collaborators` and `additional_collaborators` when creating a ticket. Unfortunately, these are arrays of elements that can have 3 different types (int, string and object), so I used `interface{}`.

I added a test and also the type specification of the object type `Collaborator`.

I thought of specifying a type that contained attributes for each possible type but this became confusing (what if more than one attribute is populated? etc).