### PR TITLE
List audits by ticket

### DIFF
--- a/zendesk/audit_test.go
+++ b/zendesk/audit_test.go
@@ -1,0 +1,27 @@
+package zendesk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListTicketAudits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode.")
+	}
+
+	client, err := NewEnvClient()
+	require.NoError(t, err)
+
+	user := randUser(t, client)
+	defer client.DeleteUser(*user.ID)
+
+	ticket := randTicket(t, client, user)
+	defer client.DeleteTicket(*ticket.ID)
+
+	// assert that a newly created ticket has an audit
+	listed, err := client.ListTicketAudits(*ticket.ID, nil)
+	require.NoError(t, err)
+	require.Len(t, listed.Audits, 1)
+}

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -44,6 +44,7 @@ type Client interface {
 	ListExternalIDTickets(string, *ListOptions, ...SideLoad) (*ListResponse, error)
 	ListRequestedTickets(int64) ([]Ticket, error)
 	ListTickets(*ListOptions, ...SideLoad) (*ListResponse, error)
+	ListTicketAudits(int64, *ListOptions) (*ListResponse, error)
 	ListTicketComments(int64) ([]TicketComment, error)
 	ListTicketCommentsFull(int64, *ListOptions, ...SideLoad) (*ListResponse, error)
 	ListTicketCollaborators(int64) ([]User, error)
@@ -271,6 +272,7 @@ func unmarshall(res *http.Response, out interface{}) error {
 type APIPayload struct {
 	Attachment                 *Attachment                `json:"attachment"`
 	Attachments                []Attachment               `json:"attachments"`
+	Audits                     []TicketAudit              `json:"audits,omitempty"`
 	Comment                    *TicketComment             `json:"comment,omitempty"`
 	Comments                   []TicketComment            `json:"comments,omitempty"`
 	ComplianceDeletionStatuses []ComplianceDeletionStatus `json:"compliance_deletion_statuses,omitempty"`
@@ -376,6 +378,7 @@ type ListResponse struct {
 	Tickets      []Ticket
 	Users        []User
 	Groups       []Group
+	Audits       []TicketAudit
 	NextPage     *string
 	PreviousPage *string
 	Count        *int64


### PR DESCRIPTION
Hi!
Just adding a new function to list Audits by ticket.
My goal is to find the tickets original email, looking for the first audit of email channel seems to do the trick.