### PR TITLE
Support sideloading for show and update ticket ops

### DIFF
--- a/zendesk/ticket_comment_test.go
+++ b/zendesk/ticket_comment_test.go
@@ -32,8 +32,9 @@ func TestTicketCommentCRUD(t *testing.T) {
 		},
 	}
 
-	ticket, err = client.UpdateTicket(*ticket.ID, &in)
+	ticketRes, err := client.UpdateTicket(*ticket.ID, &in)
 	require.NoError(t, err)
+	ticket = ticketRes.Ticket
 
 	// assert that we can list the newly created comment
 	listed, err = client.ListTicketComments(*ticket.ID)
@@ -68,8 +69,9 @@ func TestTicketCommentRedaction(t *testing.T) {
 		},
 	}
 
-	ticket, err = client.UpdateTicket(*ticket.ID, &in)
+	ticketRes, err := client.UpdateTicket(*ticket.ID, &in)
 	require.NoError(t, err)
+	ticket = ticketRes.Ticket
 
 	listed, err := client.ListTicketComments(*ticket.ID)
 	require.NoError(t, err)

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -37,6 +37,7 @@ func TestTicketCRUD(t *testing.T) {
 	require.Equal(t, created.Subject, found.Subject)
 	require.Equal(t, created.RequesterID, found.RequesterID)
 	require.Equal(t, created.Tags, found.Tags)
+	require.NotNil(t, found.CommentCount)
 
 	colls, err := client.ListTicketCollaborators(*created.ID)
 	require.NoError(t, err)
@@ -64,6 +65,7 @@ func TestTicketCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, input.Status, updated.Ticket.Status)
 	require.Len(t, updated.Ticket.CollaboratorIDs, 3)
+	require.NotNil(t, updated.Users)
 
 	requested, err := client.ListRequestedTickets(*user.ID)
 	require.NoError(t, err)

--- a/zendesk/ticket_test.go
+++ b/zendesk/ticket_test.go
@@ -31,8 +31,9 @@ func TestTicketCRUD(t *testing.T) {
 	require.Len(t, created.Tags, 1)
 	require.Len(t, created.CollaboratorIDs, 2)
 
-	found, err := client.ShowTicket(*created.ID)
+	foundRes, err := client.ShowTicket(*created.ID, IncludeCommentCount())
 	require.NoError(t, err)
+	found := foundRes.Ticket
 	require.Equal(t, created.Subject, found.Subject)
 	require.Equal(t, created.RequesterID, found.RequesterID)
 	require.Equal(t, created.Tags, found.Tags)
@@ -59,10 +60,10 @@ func TestTicketCRUD(t *testing.T) {
 		AdditionalCollaborators: []interface{}{"email3@example.com"},
 	}
 
-	updated, err := client.UpdateTicket(*created.ID, &input)
+	updated, err := client.UpdateTicket(*created.ID, &input, IncludeUsers(), IncludeCommentCount())
 	require.NoError(t, err)
-	require.Equal(t, input.Status, updated.Status)
-	require.Len(t, updated.CollaboratorIDs, 3)
+	require.Equal(t, input.Status, updated.Ticket.Status)
+	require.Len(t, updated.Ticket.CollaboratorIDs, 3)
 
 	requested, err := client.ListRequestedTickets(*user.ID)
 	require.NoError(t, err)

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -66,11 +66,11 @@ type Client interface {
 	ShowLocaleByCode(string) (*Locale, error)
 	ShowManyUsers([]int64) ([]User, error)
 	ShowOrganization(int64) (*Organization, error)
-	ShowTicket(int64) (*Ticket, error)
+	ShowTicket(int64, ...SideLoad) (*TicketResponse, error)
 	ShowUser(int64) (*User, error)
 	UpdateIdentity(int64, int64, *UserIdentity) (*UserIdentity, error)
 	UpdateOrganization(int64, *Organization) (*Organization, error)
-	UpdateTicket(int64, *Ticket) (*Ticket, error)
+	UpdateTicket(int64, *Ticket, ...SideLoad) (*TicketResponse, error)
 	UpdateUser(int64, *User) (*User, error)
 	UploadFile(string, *string, io.Reader) (*Upload, error)
 }
@@ -368,6 +368,14 @@ func Int(i int64) *int64 {
 func String(s string) *string {
 	p := s
 	return &p
+}
+
+// TicketResponse is a holder for the various returns from the ticket apis
+type TicketResponse struct {
+	Ticket        *Ticket
+	Users         []User
+	Groups        []Group
+	Organizations []Organization
 }
 
 // ListResponse is a holder for the various returns from the list apis

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -40,9 +40,9 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ticket, err := client.ShowTicket(1)
+	ticketRes, err := client.ShowTicket(1)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("Requester ID is: %d", *ticket.RequesterID)
+	log.Printf("Requester ID is: %d", *ticketRes.Ticket.RequesterID)
 }


### PR DESCRIPTION
This adds sideload support for `ShowTicket` and `UpdateTicket`, which I've found useful for my use case.

However, this is not backwards compatible, so I'm wondering what's the policy regarding these types of changes? I don't see tagged versions on the repo.