### PR TITLE
add user profile picture

### DIFF
--- a/zendesk/user.go
+++ b/zendesk/user.go
@@ -30,6 +30,7 @@ type User struct {
 	LastLoginAt         *time.Time             `json:"last_login_at,omitempty"`
 	Email               *string                `json:"email,omitempty"`
 	Phone               *string                `json:"phone,omitempty"`
+	Photo			    *Attachment            `json:"photo,omitempty"`
 	Signature           *string                `json:"signature,omitempty"`
 	Details             *string                `json:"details,omitempty"`
 	Notes               *string                `json:"notes,omitempty"`


### PR DESCRIPTION
The user's profile picture is represented as an Attachment object [link](https://developer.zendesk.com/api-reference/ticketing/users/users/#content)