### PR TITLE
add show group

### DIFF
--- a/zendesk/group.go
+++ b/zendesk/group.go
@@ -17,6 +17,15 @@ type Group struct {
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
+// ShowGroup fetches a group by its ID.
+//
+// Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/groups#show-group
+func (c *client) ShowGroup(id int64) (*Group, error) {
+	out := new(APIPayload)
+	err := c.get(fmt.Sprintf("/api/v2/groups/%d.json", id), out)
+	return out.Group, err
+}
+
 // CreateGroup creates a group.
 func (c *client) CreateGroup(group *Group) (*Group, error) {
 	in := &APIPayload{Group: group}

--- a/zendesk/group_test.go
+++ b/zendesk/group_test.go
@@ -31,6 +31,13 @@ func TestGroupCRUD(t *testing.T) {
 	require.NotNil(t, created.CreatedAt)
 	require.NotNil(t, created.UpdatedAt)
 
+	showed, err := client.ShowGroup(*created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, showed.ID)
+	require.NotNil(t, showed.URL)
+	require.NotNil(t, showed.CreatedAt)
+	require.NotNil(t, showed.UpdatedAt)
+
 	afterCreateAllGroups, err := client.ListGroups()
 	require.NoError(t, err)
 	require.True(t, len(afterCreateAllGroups) > len(beforeCreateAllGroups))

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -76,6 +76,7 @@ type Client interface {
 	ShowOrganization(int64) (*Organization, error)
 	ShowTicket(int64) (*Ticket, error)
 	ShowUser(int64) (*User, error)
+	ShowGroup(int64) (*Group, error)
 	UpdateIdentity(int64, int64, *UserIdentity) (*UserIdentity, error)
 	UpdateOrganization(int64, *Organization) (*Organization, error)
 	UpdateTicket(int64, *Ticket) (*Ticket, error)


### PR DESCRIPTION
**DESCRIPTION**

The PR adds `ShowGroup` functionality. The Zendesk API supports it as per https://developer.zendesk.com/api-reference/ticketing/groups/groups/#show-group